### PR TITLE
Update run.sh and minor cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-ROLOGPLUS Smart Connector for Chiminey
+PROLOGPLUS Smart Connector for Chiminey
 =======================================
 
 "PROLOGPLUS Smart Connector for Chiminey" allows payload parameter sweep over prolog models which facilitates scheduling computes over the cloud. In PROLOGPLUS, each compute node is insatlled with GNU PROLOG, CHARLIE, LOLA and TINA. Therefore, during job execution over a compute node, a PROLOGPLUS job can invoke GNU PROLOG, CHARLIE, LOLA and TINA from commadline (through a bash script). 

--- a/payload_prologplus/bootstrap.sh
+++ b/payload_prologplus/bootstrap.sh
@@ -48,9 +48,6 @@ for dl_url in ${jdk_download_url4[@]}; do
 done
 JAVA_TARBALL=$(basename $dl_url)
 tar xzfv $JAVA_TARBALL
-java_exe=$(whereis java 2>&1 | awk '/java/ {print $2}')
-java_path=$(dirname $java_exe)
-export PATH=$PATH:$java_path
 cd /opt/charlie
 tar -zxvf $CHARLIE_PACKAGE_NAME
 cd $WORK_DIR

--- a/payload_prologplus/process_payload/run.sh
+++ b/payload_prologplus/process_payload/run.sh
@@ -6,6 +6,9 @@ OUTPUT_DIR=$2
 cd $INPUT_DIR
 prolog_exe=$(whereis gprolog 2>&1 | awk '/gprolog/ {print $2}')
 
+java_exe=$(whereis java 2>&1 | awk '/java/ {print $2}')
+java_path=$(dirname $java_exe)
+export PATH=$PATH:$java_path
 
 $prolog_exe $(cat gprolog_command_line.txt) &> runlog.txt
 

--- a/payload_prologplus/process_payload/run.sh
+++ b/payload_prologplus/process_payload/run.sh
@@ -10,7 +10,7 @@ java_exe=$(whereis java 2>&1 | awk '/java/ {print $2}')
 java_path=$(dirname $java_exe)
 export PATH=$PATH:$java_path
 
-$prolog_exe $(cat gprolog_command_line.txt) &> runlog.txt
+MAX_ATOM=131064 GLOBALSZ=131064 $prolog_exe $(cat gprolog_command_line.txt) &> runlog.txt
 
 
 cp ./*.txt ../$OUTPUT_DIR


### PR DESCRIPTION
This PR:
- Adds Java to the PATH in run.sh instead of bootstrap.sh
- Increases MAX_ATOM and GLOBALSZ environment variables for GNU Prolog (to support large models)
- Fixes a typo in README.md
